### PR TITLE
fix an incorrectly provided argument that causes compile error(#10)

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -288,7 +288,7 @@
   // Outline
   set outline(
     // target: heading.where(level: 1),
-    indent: true,
+    indent: auto,
   )
 
   show outline: set heading(level: 2) // To not make the TOC heading a section slide by itself


### PR DESCRIPTION
As described in #10, now the package cannot compile since the `indent` argument in lib.typ:291 is incorrectly provided with a boolean value. This is an attempt to fix it, and please let me know if the author want better way to fix it.