### PR TITLE
chore: list dot-section in the template options

### DIFF
--- a/example/example.typ
+++ b/example/example.typ
@@ -10,7 +10,7 @@
   ratio: 4/3, // aspect ratio of the slides, any valid number
   layout: "medium", // one of "small", "medium", "large"
   toc: true,
-  count: "dot", // one of "dot", "number", or none
+  count: "dot", // one of "dot", "dot-section", "number", or none
   footer: true,
   // footer-title: "Custom Title",
   // footer-subtitle: "Custom Subtitle",


### PR DESCRIPTION
The comment seemed to provide an exhaustive list of options, but the `dot-section` one was missing there.
It seems appropriate to add it as there aren't dozens of different options.

I'll used the occasion to ask, in case it'd need to be clarified: same line ends with `or none`, should it be understood as literally writing `none`, and in such case, it's curious it's unquoted as opposed to the other options? Or does that just mean getting rid of the line?
It seems ambiguous to me, but that might be because I'm pretty new to Typst and English isn't my native language :)
(I didn't test right now as my tests were on $work computer).